### PR TITLE
Hide mobile menu on link click

### DIFF
--- a/src/js/hamburger.js
+++ b/src/js/hamburger.js
@@ -2,10 +2,22 @@ export function initHamburgerMenu() {
   const menuButton = document.querySelector('.button-menu');
   const mobileNav = document.querySelector('.main-header__nav');
   const menuIcon = document.querySelector('.button-menu__menu-icon');
+  const menuNavList = document.querySelector('.main-nav__list');
   const closeIcon = document.querySelector('.button-menu__close-icon');
   const mainHeader = document.querySelector('.main-header');
 
-  menuButton.addEventListener('click', function () {
+  menuButton.addEventListener('click', toggleMenu, false);
+
+  menuNavList.addEventListener('click', function(event) {
+    if (
+      window.getComputedStyle(menuButton).display !== 'none' && // Hamburger menu mode
+      event.target && event.target.nodeName === 'A'
+    ) {
+      toggleMenu();
+    }
+  }, false);
+
+  function toggleMenu() {
     mobileNav.classList.toggle('main-header__nav--nav-open');
     menuIcon.classList.toggle('button-menu__menu-icon--nav-open');
     closeIcon.classList.toggle('button-menu__close-icon--nav-open');
@@ -18,5 +30,5 @@ export function initHamburgerMenu() {
         menuButton.setAttribute('aria-expanded', 'false');
       }
     }
-  }, false);
+  }
 }


### PR DESCRIPTION
As the title states, it's a bit annoying when you have to close the menu manually.
`window.getComputedStyle` isn't really performant, but shouldn't affect the site in this case. Unless you have a better solution.