### PR TITLE
Wrong argument name given for smoothScroll.init()

### DIFF
--- a/src/js/scroll.js
+++ b/src/js/scroll.js
@@ -16,7 +16,7 @@ export function initScroll() {
 
   debounce(smoothScroll.init({
     offset: scrollOffset,
-    callback: closeNav
+    before: closeNav
   }));
 
   function closeNav() {


### PR DESCRIPTION
It causes mobile menu not to hide on link click