### PR TITLE
Hide mobile menu on menu item click

### DIFF
--- a/src/js/hamburger.js
+++ b/src/js/hamburger.js
@@ -4,8 +4,9 @@ export function initHamburgerMenu() {
   const menuIcon = document.querySelector('.button-menu__menu-icon');
   const closeIcon = document.querySelector('.button-menu__close-icon');
   const mainHeader = document.querySelector('.main-header');
+  const menuItems = document.querySelectorAll('.main-nav__item a');
 
-  menuButton.addEventListener('click', function () {
+  function toggleHamburgerMenu() {
     mobileNav.classList.toggle('main-header__nav--nav-open');
     menuIcon.classList.toggle('button-menu__menu-icon--nav-open');
     closeIcon.classList.toggle('button-menu__close-icon--nav-open');
@@ -18,5 +19,15 @@ export function initHamburgerMenu() {
         menuButton.setAttribute('aria-expanded', 'false');
       }
     }
+  }
+
+  menuButton.addEventListener('click', function () {
+    toggleHamburgerMenu();
   }, false);
+
+  Array.from(menuItems).forEach(link => {
+    link.addEventListener('click', function () {
+      toggleHamburgerMenu();
+    });
+  });
 }


### PR DESCRIPTION
Menu should hide when I click the menu item on mobile. 

Tested on iOS and Android devices. 