### PR TITLE
Reduce right offset for venue__building-image to fit into main column

### DIFF
--- a/src/scss/modules/_venue.scss
+++ b/src/scss/modules/_venue.scss
@@ -26,7 +26,7 @@
 
     @include mediaquery('gt-small') {
       width: 200px;
-      right: calc(-100% / 12 * 1);
+      right: calc(-100% / 12 * 0.5);
     }
 
     @include mediaquery('gt-medium') {


### PR DESCRIPTION
Reduce right offset for venue__building-image to fit into main column on iPad 2 Portrait.
UX Related - For iPad 2 Portrait horizontal scroll was appearing.
