### PR TITLE
Fixed "#speakers" section width to match other sections

### DIFF
--- a/src/scss/modules/_speakers.scss
+++ b/src/scss/modules/_speakers.scss
@@ -11,7 +11,7 @@
       max-width: 700px;
     }
     @include mediaquery('gt-medium') {
-      max-width: 1140px;
+      width: 590px;
     }
   }
   &__info {


### PR DESCRIPTION
sekcja #speakers jest nieodpowiednio wyrównana