### PR TITLE
feat: extract BecomeASponsor component and reorder sections for improved user flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,18 @@
 import SocketDevLogo from '@/assets/partners/gold/socket.png';
-import PlanbyLogo from '@/assets/partners/hello/planby-pro.png';
 import CyberfolksLogo from '@/assets/partners/hello/cyberfolks.svg';
+import PlanbyLogo from '@/assets/partners/hello/planby-pro.png';
 import SlidoLogo from '@/assets/partners/slido.svg';
+import { BecomeASponsor } from '@/components/become-a-sponsor.tsx';
 import { CFP } from '@/components/cfp.tsx';
 import { Charity } from '@/components/charity.tsx';
 import { LoveLetter } from '@/components/love-letter.tsx';
 import { Partners } from '@/components/partners.tsx';
-import { Speakers } from '@/components/speakers.tsx';
 import { PhotosSlider } from '@/components/photos-slider.tsx';
+import { Speakers } from '@/components/speakers.tsx';
 import { Venue } from '@/components/venue.tsx';
+import { useErrorTracking } from '@/hooks/useErrorTracking';
 import { useScrollDepthTracking } from '@/hooks/useScrollDepthTracking';
 import { useTimeOnPageTracking } from '@/hooks/useTimeOnPageTracking';
-import { useErrorTracking } from '@/hooks/useErrorTracking';
 
 import { Hero } from './components/hero.tsx';
 import { Tickets } from './components/tickets.tsx';
@@ -85,8 +86,8 @@ const partners: Partner[] = [
 		logoUrl: CyberfolksLogo,
 		websiteUrl: 'https://cyberfolks.pl/',
 		type: 'hello',
-  },
-  {
+	},
+	{
 		name: 'Instytut Fullstack',
 		logoUrl: 'https://instytutfullstack.pl/assets/newLogoVector.svg',
 		websiteUrl: 'https://instytutfullstack.pl',
@@ -103,15 +104,15 @@ export const App = () => {
 		<>
 			<Hero />
 			<LoveLetter />
-			<CFP />
+			<Tickets />
 			<Partners partners={partners} />
 			<Speakers />
 			<Venue />
-			<Tickets />
 			<PhotosSlider />
 			<Charity />
+			<CFP />
+			<BecomeASponsor />
 			{/*<CoOrganizer />*/}
 		</>
 	);
 };
-

--- a/src/components/become-a-sponsor.tsx
+++ b/src/components/become-a-sponsor.tsx
@@ -1,0 +1,80 @@
+import { Wrapper } from '@/components/wrapper.tsx';
+import * as gtag from '@/utils/gtag';
+
+export const BecomeASponsor = () => {
+	const handleSponsorOfferDownload = () => {
+		gtag.event({
+			action: 'download',
+			category: 'sponsorship',
+			label: 'Sponsor Offer PDF',
+		});
+	};
+
+	const handleContactClick = () => {
+		gtag.event({
+			action: 'click',
+			category: 'sponsorship',
+			label: 'Contact Email',
+		});
+	};
+
+	return (
+		<section id="become-a-sponsor" className="bg-black py-16 text-white">
+			<Wrapper>
+				<div className="border-t border-white/10 pt-24 pb-24 text-left">
+					<div className="grid gap-12 md:grid-cols-2 md:items-center">
+						<div className="flex flex-col gap-6">
+							<h2 className="text-4xl leading-[140%] font-semibold tracking-tight text-meetjs-green md:text-[40px]">
+								Become a Sponsor
+							</h2>
+							<div className="space-y-4 text-sm leading-[140%] tracking-tight text-aidevs-white md:text-base">
+								<p>
+									Show your brand at meet.js Summit - the 15th anniversary of
+									meet.js community in Poland. It's a for-charity, community
+									driven, Web Technology meets AI conference - attended by over
+									500 professionals.
+								</p>
+								<p>
+									At the Summit you will meet people working in the web
+									technology space and AI builders. We're not just bolting-on AI
+									- we've partnered with the best AI educators we know - AI_devs
+									by Brave courses.
+								</p>
+								<p>
+									Take action here and now - make a real connection in person
+									and get your candidates emotionally engaged from the start!
+								</p>
+								<p className="font-semibold">
+									Download our Sponsorship Offer (PDF) to find out more and
+									contact us directly to discuss sponsorship opportunities.
+								</p>
+							</div>
+						</div>
+
+						<div className="flex flex-col items-center justify-center gap-6 rounded-2xl border border-white/10 bg-white/5 p-8 text-center md:p-12">
+							<h3 className="text-xl font-bold">Ready to join us?</h3>
+							<div className="flex w-full max-w-sm flex-col gap-4">
+								<a
+									href="/2026/pdf/sponsor-offer-meetjs-2026.pdf"
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={handleSponsorOfferDownload}
+									className="rounded bg-meetjs-green px-8 py-4 font-bold text-black transition-transform hover:scale-105 active:scale-95"
+								>
+									Download Offer (PDF)
+								</a>
+								<a
+									href="mailto:contact@meetjs.pl"
+									onClick={handleContactClick}
+									className="rounded border-2 border-white px-8 py-4 font-bold text-white transition-colors hover:bg-white hover:text-black"
+								>
+									Contact Us
+								</a>
+							</div>
+						</div>
+					</div>
+				</div>
+			</Wrapper>
+		</section>
+	);
+};

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -36,18 +36,10 @@ export const Footer = () => {
 							<ul className="space-y-2">
 								<li>
 									<a
-										href="#cfp"
+										href="#tickets"
 										className="text-white-2 transition-colors hover:text-meetjs-green"
 									>
-										CFP
-									</a>
-								</li>
-								<li>
-									<a
-										href="#speakers"
-										className="text-white-2 transition-colors hover:text-meetjs-green"
-									>
-										Speakers
+										Tickets
 									</a>
 								</li>
 								<li>
@@ -60,19 +52,26 @@ export const Footer = () => {
 								</li>
 								<li>
 									<a
+										href="#speakers"
+										className="text-white-2 transition-colors hover:text-meetjs-green"
+									>
+										Speakers
+									</a>
+								</li>
+								<li>
+									<a
 										href="#venue"
 										className="text-white-2 transition-colors hover:text-meetjs-green"
 									>
 										Venue
 									</a>
 								</li>
-
 								<li>
 									<a
-										href="#tickets"
+										href="#cfp"
 										className="text-white-2 transition-colors hover:text-meetjs-green"
 									>
-										Tickets
+										CFP
 									</a>
 								</li>
 							</ul>

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -19,10 +19,11 @@ export const Navigation = () => {
 	}, []);
 
 	const navItems = [
-		{ label: 'CFP', id: 'cfp' },
-		{ label: 'Sponsor', id: 'partners' },
+		{ label: 'Tickets', id: 'tickets' },
+		{ label: 'Partners', id: 'partners' },
 		{ label: 'Speakers', id: 'speakers' },
 		{ label: 'Venue', id: 'venue' },
+		{ label: 'CFP', id: 'cfp' },
 		{ label: 'Contact', id: 'contact' },
 	];
 
@@ -68,13 +69,6 @@ export const Navigation = () => {
 								{item.label}
 							</a>
 						))}
-						<a
-							href="#tickets"
-							onClick={() => handleNavClick('Get your ticket')}
-							className="rounded-lg bg-meetjs-green px-6 py-2.5 text-sm font-bold text-black transition-all hover:bg-meetjs-green/90 hover:shadow-lg hover:shadow-meetjs-green/20"
-						>
-							Get your ticket
-						</a>
 					</div>
 
 					<button
@@ -114,13 +108,6 @@ export const Navigation = () => {
 									{item.label}
 								</a>
 							))}
-							<a
-								href="#tickets"
-								onClick={() => handleNavClick('Get your ticket')}
-								className="mt-2 rounded-lg bg-meetjs-green px-6 py-3 text-center text-base font-bold text-black transition-all hover:bg-meetjs-green/90"
-							>
-								Get your ticket
-							</a>
 						</div>
 					</div>
 				)}
@@ -128,4 +115,3 @@ export const Navigation = () => {
 		</nav>
 	);
 };
-

--- a/src/components/partners.tsx
+++ b/src/components/partners.tsx
@@ -1,6 +1,5 @@
 import { PartnersLogos } from '@/components/partners-logos.tsx';
 import { Wrapper } from '@/components/wrapper.tsx';
-import * as gtag from '@/utils/gtag';
 
 import type { Partner } from '@/types/partner.ts';
 
@@ -14,22 +13,6 @@ export const Partners = ({ partners }: PartnersProps) => {
 	const goldSponsors = partners.filter(p => p.type === 'gold');
 	const silverSponsors = partners.filter(p => p.type === 'silver');
 	const helloSponsors = partners.filter(p => p.type === 'hello');
-
-	const handleSponsorOfferDownload = () => {
-		gtag.event({
-			action: 'download',
-			category: 'sponsorship',
-			label: 'Sponsor Offer PDF',
-		});
-	};
-
-	const handleContactClick = () => {
-		gtag.event({
-			action: 'click',
-			category: 'sponsorship',
-			label: 'Contact Email',
-		});
-	};
 
 	return (
 		<section id="partners" className="bg-black py-16 text-white">
@@ -65,61 +48,7 @@ export const Partners = ({ partners }: PartnersProps) => {
 				{realPartners.length !== 0 && (
 					<PartnersLogos title="Partners" partners={realPartners} />
 				)}
-				<div className="mt-24 border-t border-white/10 pt-24 pb-24 text-left">
-					<div className="grid gap-12 md:grid-cols-2 md:items-center">
-						<div className="flex flex-col gap-6">
-							<h2 className="text-4xl leading-[140%] font-semibold tracking-tight text-meetjs-green md:text-[40px]">
-								Become a Sponsor
-							</h2>
-							<div className="space-y-4 text-sm leading-[140%] tracking-tight text-aidevs-white md:text-base">
-								<p>
-									Show your brand at meet.js Summit - the 15th anniversary of
-									meet.js community in Poland. It's a for-charity, community
-									driven, Web Technology meets AI conference - attended by over
-									500 professionals.
-								</p>
-								<p>
-									At the Summit you will meet people working in the web
-									technology space and AI builders. We're not just bolting-on AI
-									- we've partnered with the best AI educators we know - AI_devs
-									by Brave courses.
-								</p>
-								<p>
-									Take action here and now - make a real connection in person
-									and get your candidates emotionally engaged from the start!
-								</p>
-								<p className="font-semibold">
-									Download our Sponsorship Offer (PDF) to find out more and
-									contact us directly to discuss sponsorship opportunities.
-								</p>
-							</div>
-						</div>
-
-						<div className="flex flex-col items-center justify-center gap-6 rounded-2xl border border-white/10 bg-white/5 p-8 text-center md:p-12">
-							<h3 className="text-xl font-bold">Ready to join us?</h3>
-							<div className="flex w-full max-w-sm flex-col gap-4">
-								<a
-									href="/2026/pdf/sponsor-offer-meetjs-2026.pdf"
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={handleSponsorOfferDownload}
-									className="rounded bg-meetjs-green px-8 py-4 font-bold text-black transition-transform hover:scale-105 active:scale-95"
-								>
-									Download Offer (PDF)
-								</a>
-								<a
-									href="mailto:contact@meetjs.pl"
-									onClick={handleContactClick}
-									className="rounded border-2 border-white px-8 py-4 font-bold text-white transition-colors hover:bg-white hover:text-black"
-								>
-									Contact Us
-								</a>
-							</div>
-						</div>
-					</div>
-				</div>
 			</Wrapper>
 		</section>
 	);
 };
-


### PR DESCRIPTION

- Extract "Become a Sponsor" section from Partners component into separate BecomeASponsor component
- Reorder sections in App: move Tickets before Partners, CFP after Charity, and add BecomeASponsor at the end
- Update navigation and footer to reflect new section order (Tickets, Partners, Speakers, Venue, CFP)
- Remove "Get your ticket" CTA button from navigation
- Fix indentation in partners array (spaces to tabs)