### PR TITLE
feat: add previous summit years links in footer and fix 2023 base href

### DIFF
--- a/legacy-pages/2023/index.html
+++ b/legacy-pages/2023/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head prefix="website: http://ogp.me/ns/website#">
-  <base href="/2020/">
   <meta charset="utf-8"/>
   <title>meet.js Summit 2023 Wrocław</title>
   <meta

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -172,7 +172,7 @@ export const Footer = () => {
 						<p className="text-sm text-white-2">
 							© {currentYear} meet.js Summit. All rights reserved.
 						</p>
-						<div className="flex gap-6 text-sm">
+						<div className="flex flex-wrap gap-6 text-sm">
 							<a
 								href="https://berlincodeofconduct.org/"
 								target="_blank"
@@ -197,16 +197,23 @@ export const Footer = () => {
 							>
 								Terms & Conditions
 							</a>
-
-							<a
-								href="https://summit.meetjs.pl/2023/?utm_source=website&utm_medium=logo&utm_campaign=meetjs_summit_2026"
-								target="_blank"
-								rel="noopener noreferrer"
-								className="text-white-2 transition-colors hover:text-meetjs-green"
-							>
-								Previous Events
-							</a>
 						</div>
+					</div>
+					<div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 pb-6 text-sm">
+						<span className="text-white-2">Previous Summits:</span>
+						{[2012, 2013, 2014, 2016, 2017, 2018, 2019, 2022, 2023, 2024].map(
+							year => (
+								<a
+									key={year}
+									href={`https://summit.meetjs.pl/${year}/?utm_source=website&utm_medium=logo&utm_campaign=meetjs_summit_2026`}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="text-white-2 transition-colors hover:text-meetjs-green"
+								>
+									{year}
+								</a>
+							),
+						)}
 					</div>
 				</Wrapper>
 			</div>


### PR DESCRIPTION
- Remove incorrect base href from 2023 legacy page
- Replace single "Previous Events" link with individual year links (2012-2024)
- Add flex-wrap to footer links for better responsive layout
- Display previous summits in a separate row with clear label
<img width="1347" height="287" alt="Screenshot 2026-02-17 at 20 14 16" src="https://github.com/user-attachments/assets/5594fcb1-89a7-471c-be86-34e9852c0f46" />
