### PR TITLE
feat: add Testimonials section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { OrganizersSection } from '@/components/organizers-section.tsx';
 import { Partners } from '@/components/partners.tsx';
 import { PhotosSlider } from '@/components/photos-slider.tsx';
 import { Speakers } from '@/components/speakers.tsx';
+import { Testimonials } from '@/components/testimonials.tsx';
 import { Venue } from '@/components/venue.tsx';
 import { VideoPlaylists } from '@/components/video-playlists.tsx';
 import { useErrorTracking } from '@/hooks/useErrorTracking';
@@ -27,6 +28,7 @@ export const App = () => {
 			<Tickets />
 			<Partners />
 			<Speakers />
+			<Testimonials />
 			<Debate />
 			<Venue />
 			<PhotosSlider />

--- a/src/components/testimonials.tsx
+++ b/src/components/testimonials.tsx
@@ -1,0 +1,77 @@
+import { Wrapper } from '@/components/wrapper.tsx';
+
+interface Testimonial {
+	quote: string;
+	name: string;
+	role: string;
+	company: string;
+	imageUrl: string;
+}
+
+const testimonials: Testimonial[] = [
+	{
+		quote: 'An incredible experience! The talks were top-notch and the networking opportunities were unmatched. I left feeling inspired and full of new ideas.',
+		name: 'Anna Kowalska',
+		role: 'Senior Frontend Developer',
+		company: 'TechCorp',
+		imageUrl: 'https://i.pravatar.cc/150?img=1',
+	},
+	{
+		quote: "meet.js Summit is hands down the best JavaScript conference in Poland. The community vibe is amazing and every edition keeps getting better.",
+		name: 'Marcin Nowak',
+		role: 'Tech Lead',
+		company: 'StartupHub',
+		imageUrl: 'https://i.pravatar.cc/150?img=3',
+	},
+	{
+		quote: 'From the speakers to the venue to the after-party — everything was perfectly organized. Cannot wait for the next edition!',
+		name: 'Katarzyna Wiśniewska',
+		role: 'Full Stack Engineer',
+		company: 'DevStudio',
+		imageUrl: 'https://i.pravatar.cc/150?img=5',
+	},
+];
+
+export const Testimonials = () => {
+	return (
+		<section id="testimonials" className="bg-black py-16">
+			<Wrapper>
+				<h2 className="mb-4 text-center text-4xl font-semibold tracking-tight text-meetjs-green md:text-[40px]">
+					Testimonials
+				</h2>
+				<p className="mb-12 text-center text-sm leading-[140%] text-aidevs-white md:text-base">
+					What attendees say about meet.js Summit
+				</p>
+
+				<div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+					{testimonials.map((testimonial) => (
+						<div
+							key={testimonial.name}
+							className="flex flex-col rounded-2xl border border-white/10 bg-white/5 p-6"
+						>
+							<blockquote className="mb-6 flex-1 text-sm leading-relaxed text-aidevs-white md:text-base">
+								"{testimonial.quote}"
+							</blockquote>
+
+							<div className="flex items-center gap-4">
+								<img
+									src={testimonial.imageUrl}
+									alt={testimonial.name}
+									className="h-12 w-12 rounded-full object-cover"
+								/>
+								<div>
+									<p className="font-semibold text-white">
+										{testimonial.name}
+									</p>
+									<p className="text-sm text-white/60">
+										{testimonial.role}, {testimonial.company}
+									</p>
+								</div>
+							</div>
+						</div>
+					))}
+				</div>
+			</Wrapper>
+		</section>
+	);
+};


### PR DESCRIPTION
## Summary
- Add a new Testimonials section to the homepage, placed after Speakers
- Displays attendee quotes in a responsive 3-column card grid with photo, name, and role
- Uses placeholder data to be replaced with real testimonials later

<img width="1506" height="1004" alt="Screenshot 2026-02-18 at 00 34 49" src="https://github.com/user-attachments/assets/6fdc1a1b-c5cc-4493-9dd5-289dde1211c7" />

## Test plan
- [ ] Verify the section renders between Speakers and Debate on the homepage
- [ ] Check responsive layout at mobile and desktop breakpoints
- [ ] Replace placeholder content with real testimonials

🤖 Generated with [Claude Code](https://claude.com/claude-code)