### PR TITLE
feat: add YouTube Shorts section after Hero

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { PhotosSlider } from '@/components/photos-slider.tsx';
 import { Speakers } from '@/components/speakers.tsx';
 import { Venue } from '@/components/venue.tsx';
 import { VideoPlaylists } from '@/components/video-playlists.tsx';
+import { YoutubeShorts } from '@/components/youtube-shorts.tsx';
 import { useErrorTracking } from '@/hooks/useErrorTracking';
 import { useScrollDepthTracking } from '@/hooks/useScrollDepthTracking';
 import { useTimeOnPageTracking } from '@/hooks/useTimeOnPageTracking';
@@ -24,6 +25,7 @@ export const App = () => {
 	return (
 		<>
 			<Hero />
+			<YoutubeShorts />
 			<LoveLetter />
 			<Agenda />
 			<Speakers />

--- a/src/components/speakers.tsx
+++ b/src/components/speakers.tsx
@@ -115,6 +115,7 @@ const speakers: Speaker[] = [
 			'You’ll walk away knowing what your agent is doing when no one is watching. No more black boxes.',
 		bio: 'He talks and records content on front-end, node.js and web development topics. Co-organizer of meet.js Gdańsk meetup. One of the talking heads on “Śniadanie z Programowaniem” and other video formats by JustJoin.it',
 		imageUrl: MichalMichalczuk,
+		youtubeShort: 'https://youtube.com/shorts/9cGMeEruL1o',
 		social: {
 			linkedin: 'https://www.linkedin.com/in/michalczukm/',
 		},

--- a/src/components/youtube-shorts.tsx
+++ b/src/components/youtube-shorts.tsx
@@ -1,0 +1,85 @@
+const SHORTS = [
+	{
+		id: '1',
+		title: 'When AI does whatever it wants — Mateusz Chrobok',
+		url: 'https://www.youtube.com/shorts/Ai9KDYleSsQ',
+		embedId: 'Ai9KDYleSsQ',
+	},
+	{
+		id: '2',
+		title: 'Jak naprawdę pracować z AI? Mateusz Chrobok na meet.js 2026',
+		url: 'https://youtube.com/shorts/d7fr-qfX3vk',
+		embedId: 'd7fr-qfX3vk',
+	},
+	{
+		id: '3',
+		title: 'AI Agent to tylko while loop z API? 👀',
+		url: 'https://youtube.com/shorts/9cGMeEruL1o',
+		embedId: '9cGMeEruL1o',
+	},
+];
+
+export const YoutubeShorts = () => {
+	return (
+		<section className="bg-black py-16 lg:py-24">
+			<div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+				<div className="mb-12 text-center">
+					<h2 className="mb-4 text-4xl font-bold text-white sm:text-5xl">
+						Shorts
+					</h2>
+					<p className="mx-auto max-w-2xl text-lg text-gray-300">
+						Quick glimpses from meet.js Summit — straight from our YouTube
+						Shorts.
+					</p>
+				</div>
+
+				<div className="flex flex-col items-center gap-8 sm:flex-row sm:justify-center">
+					{SHORTS.map(short => (
+						<a
+							key={short.id}
+							href={short.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="group relative flex w-full max-w-[280px] flex-col overflow-hidden rounded-2xl bg-gray-900 shadow-lg transition-all duration-300 hover:scale-[1.03] hover:shadow-2xl hover:shadow-meetjs-green/20 focus:ring-2 focus:ring-meetjs-green focus:ring-offset-2 focus:ring-offset-black focus:outline-none"
+						>
+							<div className="relative" style={{ aspectRatio: '9/16' }}>
+								<iframe
+									src={`https://www.youtube.com/embed/${short.embedId}?rel=0`}
+									title={short.title}
+									allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+									allowFullScreen
+									className="pointer-events-none h-full w-full"
+									loading="lazy"
+								/>
+								{/* Click overlay so the <a> captures the click */}
+								<div className="absolute inset-0" />
+							</div>
+
+							<div className="p-4">
+								<p className="text-sm font-semibold text-white transition-colors group-hover:text-meetjs-green">
+									{short.title}
+								</p>
+								<div className="mt-2 flex items-center gap-1 text-xs font-medium text-meetjs-green">
+									<span>Watch Short</span>
+									<svg
+										className="h-3 w-3 transition-transform duration-300 group-hover:translate-x-1"
+										fill="none"
+										stroke="currentColor"
+										viewBox="0 0 24 24"
+									>
+										<path
+											strokeLinecap="round"
+											strokeLinejoin="round"
+											strokeWidth={2}
+											d="M9 5l7 7-7 7"
+										/>
+									</svg>
+								</div>
+							</div>
+						</a>
+					))}
+				</div>
+			</div>
+		</section>
+	);
+};


### PR DESCRIPTION
- New YoutubeShorts component with 3 shorts (Mateusz Chrobok x2, Michał Michalczuk)
- Section placed directly after Hero in App.tsx
- Added youtubeShort field to Michał Michalczuk's speaker entry

<img width="1392" height="886" alt="Screenshot 2026-02-25 at 22 58 11" src="https://github.com/user-attachments/assets/92c8c517-92f2-462c-9e49-743bcfb9bf5e" />
<img width="1248" height="849" alt="Screenshot 2026-02-25 at 22 58 14" src="https://github.com/user-attachments/assets/3725ad87-f60a-4d6d-896f-9d273365255e" />
